### PR TITLE
Add streaming ingest endpoint

### DIFF
--- a/garage-inventory/app/api/stream/ingest/route.ts
+++ b/garage-inventory/app/api/stream/ingest/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'crypto';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+// Simple streaming ingest endpoint. Accepts binary chunks uploaded from the
+// client and returns the current queue depth. For now, the chunks are simply
+// consumed and discarded.
+export async function POST(req: NextRequest) {
+  // Optional bearer token gate; reuse INGEST_TOKEN if set.
+  const expectedToken = process.env.INGEST_TOKEN;
+  if (expectedToken) {
+    const authHeader = req.headers.get('authorization') || '';
+    if (authHeader !== `Bearer ${expectedToken}`) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+  }
+
+  try {
+    // Read the uploaded chunk into a buffer.
+    const chunk = Buffer.from(await req.arrayBuffer());
+
+    // Store the chunk in the `stream` storage bucket with a random name. The
+    // bucket is expected to exist ahead of time.
+    const fileName = `${randomUUID()}.webm`;
+    const { error: uploadErr } = await supabaseAdmin.storage
+      .from('stream')
+      .upload(fileName, chunk, {
+        contentType: 'video/webm',
+        upsert: false,
+      });
+    if (uploadErr) {
+      throw new Error(uploadErr.message);
+    }
+
+    // Count how many chunks currently exist to approximate queue depth.
+    const { data: files, error: listErr } = await supabaseAdmin.storage
+      .from('stream')
+      .list();
+    if (listErr) {
+      throw new Error(listErr.message);
+    }
+
+    const queued = files?.length ?? 0;
+    return NextResponse.json({ queued });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message || 'ingest_failed' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/stream/ingest` route to accept binary video chunks and respond with queue depth
- save uploaded chunks to Supabase storage and report current backlog

## Testing
- `npm test` *(fails: Missing script "test")*
- `SUPABASE_URL=... SUPABASE_SERVICE_KEY=... npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c31cb69be88331b639e55b70259476