### PR TITLE
Add authorization header for ingest stream uploads

### DIFF
--- a/garage-inventory/app/static/js/scan.js
+++ b/garage-inventory/app/static/js/scan.js
@@ -38,6 +38,9 @@
   const CHUNK_MS = 500; // 2 FPS baseline
   recorder.start(CHUNK_MS);
 
+  const INGEST_TOKEN = window.INGEST_TOKEN;
+  const headers = INGEST_TOKEN ? { Authorization: `Bearer ${INGEST_TOKEN}` } : {};
+
   const QUEUE_THRESHOLD = 5;
   let paused = false;
 
@@ -56,6 +59,7 @@
         const res = await fetch('/api/stream/ingest', {
           method: 'POST',
           body: chunk,
+          headers,
         });
         let data = {};
         try {


### PR DESCRIPTION
## Summary
- include optional ingest token from config in scan.js
- send bearer auth header with camera chunk uploads

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c32e73285883318f6b0ec77519e31e