### PR TITLE
Handle fetch errors in garage page and redirect root

### DIFF
--- a/garage-inventory/app/garage/page.tsx
+++ b/garage-inventory/app/garage/page.tsx
@@ -1,17 +1,30 @@
 import GarageCapture from '@/components/GarageCapture';
+import { headers } from 'next/headers';
 
 export default async function GaragePage({ searchParams }: { searchParams: { q?: string } }) {
   async function fetchItems(query?: string) {
-   // baseUrl set to empty string so relative API calls work in all environments.
-   const baseUrl = '';
- const url = query
+    const headersList = headers();
+    const host = headersList.get('host') ?? 'localhost:3000';
+    const protocol = headersList.get('x-forwarded-proto') ?? 'http';
+    const baseUrl = `${protocol}://${host}`;
+    const url = query
       ? `${baseUrl}/api/items?q=${encodeURIComponent(query)}`
       : `${baseUrl}/api/items`;
-    const res = await fetch(url, { cache: 'no-store' });
-    return res.json();
+    try {
+      const res = await fetch(url, { cache: 'no-store' });
+      if (!res.ok) {
+        console.error('Failed to fetch items', res.status, res.statusText);
+        return { items: [] };
+      }
+      return res.json();
+    } catch (err) {
+      console.error('Error fetching items', err);
+      return { items: [] };
+    }
   }
 
   const data = await fetchItems(searchParams?.q);
+  const items = data.items ?? [];
 
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-6">
@@ -29,7 +42,10 @@ export default async function GaragePage({ searchParams }: { searchParams: { q?:
           Search
         </button>
       </form>
-      {data.items?.map((it: any) => (
+      {items.length === 0 && (
+        <p className="text-gray-500">No items found.</p>
+      )}
+      {items.map((it: any) => (
         <div key={it.id} className="border p-2">
           <p className="font-semibold">{it.name}</p>
           <p className="text-sm text-gray-600">

--- a/garage-inventory/app/page.tsx
+++ b/garage-inventory/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Home() {
+  redirect('/garage');
+}


### PR DESCRIPTION
## Summary
- handle failed `/api/items` calls in garage page
- show "No items found" when fetch fails or returns no items
- derive API base URL from request headers to avoid 404
- redirect root path `/` to `/garage` so the garage page shows on initial load

## Testing
- `npm run build`
- `curl -i http://localhost:3000/`


------
https://chatgpt.com/codex/tasks/task_e_68c1be3c434c83318effa92943ea445a