### PR TITLE
Forward preview cookie in items fetch

### DIFF
--- a/garage-inventory/app/garage/page.tsx
+++ b/garage-inventory/app/garage/page.tsx
@@ -10,8 +10,13 @@ export default async function GaragePage({ searchParams }: { searchParams: { q?:
     const url = query
       ? `${baseUrl}/api/items?q=${encodeURIComponent(query)}`
       : `${baseUrl}/api/items`;
+    // Grab the protection cookie and forward it
+    const cookie = headersList.get('cookie') ?? '';
     try {
-      const res = await fetch(url, { cache: 'no-store' });
+      const res = await fetch(url, {
+        cache: 'no-store',
+        headers: { cookie },
+      });
       if (!res.ok) {
         console.error('Failed to fetch items', res.status, res.statusText);
         return { items: [] };


### PR DESCRIPTION
## Summary
- forward protection cookie when fetching items from server component

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: SUPABASE_URL and SUPABASE_SERVICE_KEY must be set)


------
https://chatgpt.com/codex/tasks/task_e_68c38a046e0c83319fff1597bcf04d74