### PR TITLE
fix: supabase runtime initialization + dynamic api/page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+**/node_modules
+**/.next
+

--- a/garage-inventory/app/api/health/route.ts
+++ b/garage-inventory/app/api/health/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const ok = Boolean(process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_KEY);
+  return NextResponse.json({ ok }, { status: ok ? 200 : 500 });
+}
+

--- a/garage-inventory/app/api/items/route.ts
+++ b/garage-inventory/app/api/items/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { getSupabaseAdmin } from '@/lib/supabaseAdmin';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const runtime = 'nodejs';
 
 // GET /api/items
 // Supports optional `q` query for fuzzy search and optional `limit` to restrict
@@ -10,20 +14,21 @@ export async function GET(req: NextRequest) {
   const query = searchParams.get('q');
   const limit = Number(searchParams.get('limit') || '50');
   try {
+    const supabase = getSupabaseAdmin();
     if (query) {
-      const nameResults = await supabaseAdmin
+      const nameResults = await supabase
         .from('items')
         .select('id,name,category,confidence')
         .ilike('name', `%${query}%`)
         .limit(limit);
-      const aliasResults = await supabaseAdmin
+      const aliasResults = await supabase
         .from('item_aliases')
         .select('item_id,alias')
         .ilike('alias', `%${query}%`)
         .limit(limit);
       const aliasIds = (aliasResults.data || []).map((a: any) => a.item_id);
       const aliasItems = aliasIds.length
-        ? await supabaseAdmin
+        ? await supabase
             .from('items')
             .select('id,name,category,confidence')
             .in('id', aliasIds)
@@ -35,14 +40,15 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ items: Array.from(dedup.values()).slice(0, limit) });
     }
     // No query; return recent items
-    const { data, error } = await supabaseAdmin
+    const { data, error } = await supabase
       .from('items')
       .select('id,name,category,confidence')
       .order('created_at', { ascending: false })
       .limit(limit);
     if (error) throw new Error(error.message);
-    return NextResponse.json({ items: data });
+    return NextResponse.json({ items: data ?? [] }, { status: 200 });
   } catch (err: any) {
+    console.error('GET /api/items error:', err);
     return NextResponse.json({ error: err.message || 'items_fetch_failed' }, { status: 500 });
   }
 }

--- a/garage-inventory/app/garage/page.tsx
+++ b/garage-inventory/app/garage/page.tsx
@@ -1,6 +1,9 @@
 import GarageCapture from '@/components/GarageCapture';
 import { headers } from 'next/headers';
 
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 export default async function GaragePage({ searchParams }: { searchParams: { q?: string } }) {
   async function fetchItems(query?: string) {
     const headersList = headers();

--- a/garage-inventory/lib/supabaseAdmin.ts
+++ b/garage-inventory/lib/supabaseAdmin.ts
@@ -1,17 +1,22 @@
 import { createClient } from '@supabase/supabase-js';
 
-// This helper instantiates a Supabase client for server‑side usage. It
-// relies on the service role key, which should only ever be used on the
-// server (never exposed to the client). See `.env.example` for the
-// required environment variables. You can import this client in API
-// routes or server components to interact with your database.
+/**
+ * Returns a Supabase client using the service role key. The client is created
+ * at call time so that environment variables are only read during a request
+ * and never during build time.
+ */
+export function getSupabaseAdmin() {
+  const url = process.env.SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_KEY;
 
-const supabaseUrl = process.env.SUPABASE_URL;
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_KEY;
-if (!supabaseUrl || !supabaseServiceKey) {
-  throw new Error('SUPABASE_URL and SUPABASE_SERVICE_KEY must be set');
+  if (!url || !serviceKey) {
+    // Helpful error for logs / development
+    throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_KEY');
+  }
+
+  return createClient(url, serviceKey, {
+    auth: { persistSession: false },
+    global: { fetch },
+  });
 }
 
-export const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey, {
-  auth: { persistSession: false },
-});


### PR DESCRIPTION
## Summary
- create server-only `getSupabaseAdmin` helper to instantiate Supabase client at request time
- refactor API routes and garage page to force dynamic execution and use runtime Supabase client
- add `/api/health` endpoint and ignore build artifacts

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c3ae53c64c8331975c8a51c650da55