### PR TITLE
Add streaming session management endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+garage-inventory/node_modules
+garage-inventory/.next

--- a/garage-inventory/app/api/stream/[sessionId]/events/route.ts
+++ b/garage-inventory/app/api/stream/[sessionId]/events/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest } from 'next/server';
+import { getSession } from '@/lib/sessionStore';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { sessionId: string } }
+) {
+  const session = getSession(params.sessionId);
+  if (!session) {
+    return new Response('session_not_found', { status: 404 });
+  }
+
+  let onUpdate: ((data: any) => void) | undefined;
+  let onClose: (() => void) | undefined;
+
+  const stream = new ReadableStream({
+    start(controller) {
+      onUpdate = (data: any) => {
+        controller.enqueue(`data: ${JSON.stringify(data)}\n\n`);
+      };
+      onClose = () => controller.close();
+      session.emitter.on('update', onUpdate);
+      session.emitter.on('close', onClose);
+    },
+    cancel() {
+      if (onUpdate) session.emitter.off('update', onUpdate);
+      if (onClose) session.emitter.off('close', onClose);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+    },
+  });
+}

--- a/garage-inventory/app/api/stream/ingest/route.ts
+++ b/garage-inventory/app/api/stream/ingest/route.ts
@@ -1,18 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { randomUUID } from 'crypto';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { validateSession } from '@/lib/sessionStore';
 
 // Simple streaming ingest endpoint. Accepts binary chunks uploaded from the
 // client and returns the current queue depth. For now, the chunks are simply
 // consumed and discarded.
 export async function POST(req: NextRequest) {
-  // Optional bearer token gate; reuse INGEST_TOKEN if set.
-  const expectedToken = process.env.INGEST_TOKEN;
-  if (expectedToken) {
-    const authHeader = req.headers.get('authorization') || '';
-    if (authHeader !== `Bearer ${expectedToken}`) {
-      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
-    }
+  const { searchParams } = new URL(req.url);
+  const sessionId = searchParams.get('session_id');
+  if (!sessionId) {
+    return NextResponse.json({ error: 'missing_session' }, { status: 400 });
+  }
+
+  const authHeader = req.headers.get('authorization') || '';
+  const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : undefined;
+  if (!validateSession(sessionId, token)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
 
   try {

--- a/garage-inventory/app/api/stream/start/route.ts
+++ b/garage-inventory/app/api/stream/start/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { createSession } from '@/lib/sessionStore';
+
+export async function POST() {
+  const { id, token } = createSession();
+  const body: any = { session_id: id };
+  if (token) {
+    body.ingest_token = token;
+  }
+  return NextResponse.json(body);
+}

--- a/garage-inventory/app/api/stream/stop/route.ts
+++ b/garage-inventory/app/api/stream/stop/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession, deleteSession } from '@/lib/sessionStore';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { session_id, ingest_token } = await req.json();
+    const session = getSession(session_id);
+    if (!session) {
+      return NextResponse.json({ error: 'invalid_session' }, { status: 404 });
+    }
+    if (session.token && session.token !== ingest_token) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+    deleteSession(session_id);
+    return NextResponse.json({ success: true });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message || 'stop_failed' }, { status: 500 });
+  }
+}

--- a/garage-inventory/lib/sessionStore.ts
+++ b/garage-inventory/lib/sessionStore.ts
@@ -1,0 +1,43 @@
+import { EventEmitter } from 'events';
+import { randomUUID } from 'crypto';
+
+interface Session {
+  token?: string;
+  emitter: EventEmitter;
+}
+
+const sessions = new Map<string, Session>();
+
+export function createSession() {
+  const id = randomUUID();
+  // Generate a token only if INGEST_TOKEN env var is set
+  const token = process.env.INGEST_TOKEN ? randomUUID() : undefined;
+  sessions.set(id, { token, emitter: new EventEmitter() });
+  return { id, token };
+}
+
+export function getSession(id: string) {
+  return sessions.get(id);
+}
+
+export function deleteSession(id: string) {
+  const session = sessions.get(id);
+  if (session) {
+    session.emitter.emit('close');
+    sessions.delete(id);
+  }
+}
+
+export function validateSession(id: string, token?: string) {
+  const session = sessions.get(id);
+  if (!session) return false;
+  if (session.token && session.token !== token) return false;
+  return true;
+}
+
+export function pushUpdate(id: string, data: any) {
+  const session = sessions.get(id);
+  if (session) {
+    session.emitter.emit('update', data);
+  }
+}


### PR DESCRIPTION
## Summary
- add session store and start/stop/events API routes for streaming
- require valid session for ingest requests
- ignore build artifacts and node modules

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: SUPABASE_URL and SUPABASE_SERVICE_KEY must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b1331978833191487ea8621fb73b