### PR TITLE
feat: enforce upload limits and track queue

### DIFF
--- a/garage-inventory/app/api/stream/ingest/route.ts
+++ b/garage-inventory/app/api/stream/ingest/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { randomUUID } from 'crypto';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 
+// Maximum accepted payload size (bytes). Reject anything larger upfront.
+const MAX_BYTES = 10 * 1024 * 1024; // 10 MB
+
 // Simple streaming ingest endpoint. Accepts binary chunks uploaded from the
 // client and returns the current queue depth. For now, the chunks are simply
 // consumed and discarded.
@@ -16,11 +19,40 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    // Read the uploaded chunk into a buffer.
-    const chunk = Buffer.from(await req.arrayBuffer());
+    // Enforce payload size using Content-Length if provided.
+    const lenHeader = req.headers.get('content-length');
+    if (lenHeader) {
+      const len = Number(lenHeader);
+      if (isNaN(len) || len > MAX_BYTES) {
+        return NextResponse.json({ error: 'payload_too_large' }, { status: 413 });
+      }
+    }
 
-    // Store the chunk in the `stream` storage bucket with a random name. The
-    // bucket is expected to exist ahead of time.
+    // Ensure the request actually has a body.
+    if (!req.body) {
+      return NextResponse.json({ error: 'missing_body' }, { status: 400 });
+    }
+
+    // Stream the request body, aborting if it exceeds MAX_BYTES.
+    const reader = req.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let received = 0;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        received += value.length;
+        if (received > MAX_BYTES) {
+          return NextResponse.json({ error: 'payload_too_large' }, { status: 413 });
+        }
+        chunks.push(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    const chunk = Buffer.concat(chunks);
+
+    // Store the chunk in the `stream` storage bucket with a random name.
     const fileName = `${randomUUID()}.webm`;
     const { error: uploadErr } = await supabaseAdmin.storage
       .from('stream')
@@ -32,15 +64,23 @@ export async function POST(req: NextRequest) {
       throw new Error(uploadErr.message);
     }
 
-    // Count how many chunks currently exist to approximate queue depth.
-    const { data: files, error: listErr } = await supabaseAdmin.storage
-      .from('stream')
-      .list();
-    if (listErr) {
-      throw new Error(listErr.message);
+    // Increment and return queue depth without listing the bucket.
+    const { data: meta, error: metaErr } = await supabaseAdmin
+      .from('stream_queue')
+      .select('count')
+      .eq('id', 'stream')
+      .single();
+    let queued = (meta?.count ?? 0) + 1;
+    const { error: upsertErr } = await supabaseAdmin
+      .from('stream_queue')
+      .upsert({ id: 'stream', count: queued });
+    if (metaErr && metaErr.code !== 'PGRST116') {
+      throw new Error(metaErr.message);
+    }
+    if (upsertErr) {
+      throw new Error(upsertErr.message);
     }
 
-    const queued = files?.length ?? 0;
     return NextResponse.json({ queued });
   } catch (err: any) {
     return NextResponse.json({ error: err.message || 'ingest_failed' }, { status: 500 });


### PR DESCRIPTION
## Summary
- stream uploaded chunks instead of using arrayBuffer
- reject oversized uploads via Content-Length and max byte checks
- maintain queue depth in a counter table instead of listing bucket
- validate request body and release reader lock when streaming

## Testing
- `npm test` (fails: Missing script: "test")
- `SUPABASE_URL=... SUPABASE_SERVICE_KEY=... npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c4470a0a348331a15e56df3582ead5