### PR TITLE
refactor auth validation

### DIFF
--- a/garage-inventory/app/api/ingest/route.ts
+++ b/garage-inventory/app/api/ingest/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import { CATEGORIES, Category } from '@/lib/taxonomy';
+import { validateAuth } from '@/lib/validateAuth';
 
 // Define the shape of a detected item returned from the vision model.
 interface DetectedItem {
@@ -12,14 +13,8 @@ interface DetectedItem {
 
 // POST /api/ingest
 export async function POST(req: NextRequest) {
-  // Optional bearer token gate; if INGEST_TOKEN is set, clients must include it
-  const expectedToken = process.env.INGEST_TOKEN;
-  if (expectedToken) {
-    const authHeader = req.headers.get('authorization') || '';
-    if (authHeader !== `Bearer ${expectedToken}`) {
-      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
-    }
-  }
+  const unauthorized = validateAuth(req.headers);
+  if (unauthorized) return unauthorized;
 
   try {
     const { imageUrl, width, height } = await req.json();

--- a/garage-inventory/lib/validateAuth.test.ts
+++ b/garage-inventory/lib/validateAuth.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert';
+import { validateAuth } from './validateAuth';
+import { NextResponse } from 'next/server';
+
+// Set the environment token for tests.
+process.env.INGEST_TOKEN = 'secret';
+
+// Helper to get status from NextResponse.
+function getStatus(res: NextResponse | undefined) {
+  return res?.status;
+}
+
+// Missing Authorization header
+assert.strictEqual(getStatus(validateAuth(new Headers())), 401);
+
+// Wrong Authorization header
+assert.strictEqual(getStatus(validateAuth(new Headers({ authorization: 'Bearer wrong' }))), 401);
+
+// Correct Authorization header
+assert.strictEqual(getStatus(validateAuth(new Headers({ authorization: 'Bearer secret' }))), undefined);
+
+console.log('validateAuth tests passed');

--- a/garage-inventory/lib/validateAuth.ts
+++ b/garage-inventory/lib/validateAuth.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Validates the Authorization header against the INGEST_TOKEN environment variable.
+ * If INGEST_TOKEN is unset, all requests are permitted.
+ * @param headers Request headers to validate.
+ * @returns NextResponse if unauthorized, otherwise undefined.
+ */
+export function validateAuth(headers: Headers) {
+  const expectedToken = process.env.INGEST_TOKEN;
+  if (expectedToken) {
+    const authHeader = headers.get('authorization') || '';
+    if (authHeader !== `Bearer ${expectedToken}`) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- centralize bearer token check in `validateAuth`
- call helper from ingest routes to remove duplicate logic
- add tests covering missing, wrong, and correct tokens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Missing environment variable: SUPABASE_URL)*
- `npx tsc lib/validateAuth.ts lib/validateAuth.test.ts --module commonjs --target es2019 --esModuleInterop --skipLibCheck --outDir .test-dist && node .test-dist/validateAuth.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c44febc3848331bd294f03e8e2b5c1