### PR TITLE
Validate limit parameter range for items API

### DIFF
--- a/garage-inventory/app/api/items/route.test.ts
+++ b/garage-inventory/app/api/items/route.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+
+process.env.SUPABASE_URL = 'https://example.com';
+process.env.SUPABASE_SERVICE_KEY = 'key';
+
+async function run() {
+  const { GET } = await import('./route');
+  const highRes = await GET({ url: 'http://example.com/api/items?limit=101' } as any);
+  assert.equal(highRes.status, 400);
+
+  const lowRes = await GET({ url: 'http://example.com/api/items?limit=0' } as any);
+  assert.equal(lowRes.status, 400);
+
+  console.log('limit range enforcement tests passed');
+}
+
+run();

--- a/garage-inventory/app/api/items/route.ts
+++ b/garage-inventory/app/api/items/route.ts
@@ -8,7 +8,21 @@ import { supabaseAdmin } from '@/lib/supabaseAdmin';
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const query = searchParams.get('q');
-  const limit = Number(searchParams.get('limit') || '50');
+
+  const rawLimit = searchParams.get('limit');
+  let limit = 50;
+  if (rawLimit !== null) {
+    const parsed = Number(rawLimit);
+    if (!Number.isFinite(parsed)) {
+      limit = 50;
+    } else {
+      const clamped = Math.min(Math.max(parsed, 1), 100);
+      if (clamped !== parsed) {
+        return NextResponse.json({ error: 'limit_out_of_range' }, { status: 400 });
+      }
+      limit = clamped;
+    }
+  }
   try {
     if (query) {
       const nameResults = await supabaseAdmin


### PR DESCRIPTION
## Summary
- clamp and validate `limit` query param for /api/items, returning 400 on out-of-range values
- add a small test script to assert 400 status for limits below 1 or above 100

## Testing
- `npx tsx app/api/items/route.test.ts`
- `SUPABASE_URL=https://example.com SUPABASE_SERVICE_KEY=key npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c44fe422f08331b0c780d57177b0d0